### PR TITLE
Rename EndpointConfig to NodeConfig.

### DIFF
--- a/s2energy-connection/examples/pairing-client.rs
+++ b/s2energy-connection/examples/pairing-client.rs
@@ -3,7 +3,7 @@ use uuid::uuid;
 
 use s2energy_connection::{
     Deployment, MessageVersion, S2NodeDescription, S2Role,
-    pairing::{Client, ClientConfig, EndpointConfig, PairingRemote},
+    pairing::{Client, ClientConfig, NodeConfig, PairingRemote},
 };
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
@@ -16,7 +16,7 @@ async fn main() {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let config = EndpointConfig::builder(
+    let config = NodeConfig::builder(
         S2NodeDescription {
             id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c7").into(),
             brand: String::from("super-reliable-corp"),

--- a/s2energy-connection/examples/pairing-server.rs
+++ b/s2energy-connection/examples/pairing-server.rs
@@ -5,7 +5,7 @@ use uuid::uuid;
 
 use s2energy_connection::{
     MessageVersion, S2NodeDescription, S2Role,
-    pairing::{EndpointConfig, PairingToken, Server, ServerConfig},
+    pairing::{NodeConfig, PairingToken, Server, ServerConfig},
 };
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
@@ -24,7 +24,7 @@ async fn main() {
             CertificateDer::from_pem_file(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata").join("root.pem")).unwrap(),
         ),
     });
-    let config = EndpointConfig::builder(
+    let config = NodeConfig::builder(
         S2NodeDescription {
             id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8").into(),
             brand: String::from("super-reliable-corp"),

--- a/s2energy-connection/src/pairing/client.rs
+++ b/s2energy-connection/src/pairing/client.rs
@@ -9,16 +9,16 @@ use crate::common::wire::{AccessToken, Deployment, PairingVersion, S2NodeId, S2R
 use crate::pairing::transport::{HashProvider, hash_providing_https_client};
 use crate::pairing::{Error, Pairing, PairingRole};
 
-use super::EndpointConfig;
+use super::NodeConfig;
 use super::wire::*;
 use super::{ErrorKind, Network, PairingResult};
 
-/// Remote endpoint to pair with
+/// Remote node to pair with
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PairingRemote {
-    /// URL at which the remote endpoint can be reached
+    /// URL at which the remote node can be reached
     pub url: String,
-    /// S2 node id of the remote endpoint.
+    /// S2 node id of the remote node.
     pub id: S2NodeId,
 }
 
@@ -36,14 +36,14 @@ pub struct ClientConfig {
 ///
 /// Used as the client end of a pairing interaction.
 pub struct Client {
-    config: Arc<EndpointConfig>,
+    config: Arc<NodeConfig>,
     additional_certificates: Vec<CertificateDer<'static>>,
     pairing_deployment: Deployment,
 }
 
 impl Client {
-    /// Create a new client for pairing on an endpoint with the given configuration.
-    pub fn new(config: Arc<EndpointConfig>, client_config: ClientConfig) -> PairingResult<Self> {
+    /// Create a new client for pairing on an node with the given configuration.
+    pub fn new(config: Arc<NodeConfig>, client_config: ClientConfig) -> PairingResult<Self> {
         Ok(Self {
             config,
             additional_certificates: client_config.additional_certificates,
@@ -91,11 +91,11 @@ impl Client {
 struct V1Session<'a> {
     client: reqwest::Client,
     base_url: Url,
-    config: &'a EndpointConfig,
+    config: &'a NodeConfig,
 }
 
 impl<'a> V1Session<'a> {
-    fn new(client: reqwest::Client, url: Url, config: &'a EndpointConfig) -> Self {
+    fn new(client: reqwest::Client, url: Url, config: &'a NodeConfig) -> Self {
         V1Session {
             client,
             base_url: url.join("v1/").unwrap(),

--- a/s2energy-connection/src/pairing/error.rs
+++ b/s2energy-connection/src/pairing/error.rs
@@ -163,10 +163,10 @@ impl From<ConfigError> for ErrorKind {
     }
 }
 
-/// Error for problems with inconsistent [`EndpointConfig`]
+/// Error for problems with inconsistent [`NodeConfig`]
 #[derive(Error, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ConfigError {
-    /// The [`EndpointConfig`] doesn't have an `connection_initiate_url` even though it is needed for the configuration to make sense.
+    /// The [`NodeConfig`] doesn't have an `connection_initiate_url` even though it is needed for the configuration to make sense.
     #[error("Missing connection_initiate_url, even though it is required for CEM and WAN endpoints")]
     MissingInitiateUrl,
 }

--- a/s2energy-connection/src/pairing/mod.rs
+++ b/s2energy-connection/src/pairing/mod.rs
@@ -2,14 +2,14 @@
 //!
 //! This module provides client and server implementations of the [S2 pairing protocol](https://docs.s2standard.org/docs/communication-layer/discovery-pairing-authentication/#the-pairing-process)
 //!
-//! # Endpoint configuration
+//! # Node configuration
 //!
-//! The main configuration struct [`EndpointConfig`] describes an S2 endpoint. It is constructed through
+//! The main configuration struct [`NodeConfig`] describes an S2 node. It is constructed through
 //! a builder pattern. For simple configuration, the builder can immediately be build:
 //! ```rust
-//! # use s2energy_connection::pairing::EndpointConfig;
+//! # use s2energy_connection::pairing::NodeConfig;
 //! # use s2energy_connection::{MessageVersion, S2NodeDescription, S2NodeId, S2Role};
-//! let _config = EndpointConfig::builder(S2NodeDescription {
+//! let _config = NodeConfig::builder(S2NodeDescription {
 //!     id: S2NodeId::try_from("67e55044-10b1-426f-9247-bb680e5fe0c8").unwrap(),
 //!     brand: String::from("super-reliable-corp"),
 //!     logo_uri: None,
@@ -24,9 +24,9 @@
 //!
 //! Additional information can be added through methods on the builder. For example, we can add a connection initiate url through:
 //! ```rust
-//! # use s2energy_connection::pairing::EndpointConfig;
+//! # use s2energy_connection::pairing::NodeConfig;
 //! # use s2energy_connection::{MessageVersion, S2NodeDescription, S2NodeId, S2Role};
-//! let _config = EndpointConfig::builder(S2NodeDescription {
+//! let _config = NodeConfig::builder(S2NodeDescription {
 //!     id: S2NodeId::try_from("67e55044-10b1-426f-9247-bb680e5fe0c8").unwrap(),
 //!     brand: String::from("super-reliable-corp"),
 //!     logo_uri: None,
@@ -42,13 +42,13 @@
 //!
 //! # Client usage
 //!
-//! Given an endpoint configuration, a [`Client`] can be constructed which can be used to pair with a remote S2 node running a pairing
+//! Given a node configuration, a [`Client`] can be constructed which can be used to pair with a remote S2 node running a pairing
 //! server. For this, you will also need to know the id of the node, and the URL on which its pairing server is reachable.
 //! ```rust
 //! # use std::sync::Arc;
-//! # use s2energy_connection::pairing::{Client, ClientConfig, EndpointConfig, PairingRemote};
+//! # use s2energy_connection::pairing::{Client, ClientConfig, NodeConfig, PairingRemote};
 //! # use s2energy_connection::{Deployment, MessageVersion, S2NodeDescription, S2NodeId, S2Role};
-//! # let config = EndpointConfig::builder(S2NodeDescription {
+//! # let config = NodeConfig::builder(S2NodeDescription {
 //! #     id: S2NodeId::new(),
 //! #     brand: String::from("super-reliable-corp"),
 //! #     logo_uri: None,
@@ -105,7 +105,7 @@
 //! ```no_run
 //! # use std::{path::PathBuf, net::SocketAddr, sync::Arc};
 //! # use axum_server::tls_rustls::RustlsConfig;
-//! # use s2energy_connection::pairing::{EndpointConfig, PairingToken, Server, ServerConfig};
+//! # use s2energy_connection::pairing::{NodeConfig, PairingToken, Server, ServerConfig};
 //! # use s2energy_connection::{MessageVersion, S2NodeDescription, S2NodeId, S2Role};
 //! # #[tokio::main(flavor = "current_thread")]
 //! # async fn main() {
@@ -121,7 +121,7 @@
 //! # let server = Server::new(ServerConfig {
 //! #     root_certificate: None,
 //! # });
-//! # let config = Arc::new(EndpointConfig::builder(S2NodeDescription {
+//! # let config = Arc::new(NodeConfig::builder(S2NodeDescription {
 //! #     id: S2NodeId::new(),
 //! #     brand: String::from("super-reliable-corp"),
 //! #     logo_uri: None,
@@ -141,7 +141,7 @@
 //! ```no_run
 //! # use std::{path::PathBuf, net::SocketAddr, sync::Arc};
 //! # use axum_server::tls_rustls::RustlsConfig;
-//! # use s2energy_connection::pairing::{EndpointConfig, PairingToken, Server, ServerConfig};
+//! # use s2energy_connection::pairing::{NodeConfig, PairingToken, Server, ServerConfig};
 //! # use s2energy_connection::{MessageVersion, S2NodeDescription, S2NodeId, S2Role};
 //! # #[tokio::main(flavor = "current_thread")]
 //! # async fn main() {
@@ -157,7 +157,7 @@
 //! # let server = Server::new(ServerConfig {
 //! #     root_certificate: None,
 //! # });
-//! # let config = Arc::new(EndpointConfig::builder(S2NodeDescription {
+//! # let config = Arc::new(NodeConfig::builder(S2NodeDescription {
 //! #     id: S2NodeId::new(),
 //! #     brand: String::from("super-reliable-corp"),
 //! #     logo_uri: None,
@@ -199,9 +199,9 @@ use crate::{
     CommunicationProtocol, Deployment, MessageVersion, S2EndpointDescription, S2NodeDescription, S2Role, common::wire::AccessToken,
 };
 
-/// Full description of an S2 endpoint
+/// Full description of an S2 nodew
 #[derive(Debug, Clone)]
-pub struct EndpointConfig {
+pub struct NodeConfig {
     node_description: S2NodeDescription,
     endpoint_description: S2EndpointDescription,
     supported_message_versions: Vec<MessageVersion>,
@@ -209,35 +209,35 @@ pub struct EndpointConfig {
     connection_initiate_url: Option<String>,
 }
 
-impl EndpointConfig {
+impl NodeConfig {
     /// Description of the S2 node.
     pub fn node_description(&self) -> &S2NodeDescription {
         &self.node_description
     }
 
-    /// Description of the actual endpoint of the node.
+    /// Description of the endpoint hosting the node.
     pub fn endpoint_description(&self) -> &S2EndpointDescription {
         &self.endpoint_description
     }
 
-    /// Message versions supported by this endpoint.
+    /// Message versions supported by this node.
     pub fn supported_message_versions(&self) -> &[MessageVersion] {
         &self.supported_message_versions
     }
 
-    /// Communication protocols supported by this endpoint
+    /// Communication protocols supported by this node
     pub fn supported_communication_protocols(&self) -> &[CommunicationProtocol] {
         &self.supported_communication_protocols
     }
 
-    /// Connection initiate url used for this endpoint, if configured.
+    /// Connection initiate url used for this node, if configured.
     pub fn connection_initiate_url(&self) -> Option<&str> {
         self.connection_initiate_url.as_deref()
     }
 
-    /// Create a builder for a new [`EndpointConfig`]
+    /// Create a builder for a new [`NodeConfig`]
     ///
-    /// All endpoint configurations must at least contain description of the node and supported message versions. Additional
+    /// All node configurations must at least contain description of the node and supported message versions. Additional
     /// properties can be configured through the builder.
     pub fn builder(node_description: S2NodeDescription, supported_message_versions: Vec<MessageVersion>) -> ConfigBuilder {
         ConfigBuilder {
@@ -250,7 +250,7 @@ impl EndpointConfig {
     }
 }
 
-/// Builder for an [`EndpointConfig`]
+/// Builder for an [`NodeConfig`]
 pub struct ConfigBuilder {
     node_description: S2NodeDescription,
     endpoint_description: S2EndpointDescription,
@@ -262,7 +262,7 @@ pub struct ConfigBuilder {
 impl ConfigBuilder {
     /// Set a url for initiating new connections.
     ///
-    /// By default, this URL is not present. It is however required for CEM endpoints, or RM endpoints with a WAN deployment.
+    /// By default, this URL is not present. It is however required for CEM nodes, or RM nodes with a WAN deployment.
     pub fn with_connection_initiate_url(mut self, connection_initiate_url: String) -> Self {
         self.connection_initiate_url = Some(connection_initiate_url);
         self
@@ -282,14 +282,14 @@ impl ConfigBuilder {
         self
     }
 
-    /// Create the actual [`EndpointConfig`], validating that it is reasonable.
-    pub fn build(self) -> Result<EndpointConfig, ConfigError> {
+    /// Create the actual [`NodeConfig`], validating that it is reasonable.
+    pub fn build(self) -> Result<NodeConfig, ConfigError> {
         if (self.node_description.role == S2Role::Cem || self.endpoint_description.deployment == Some(Deployment::Wan))
             && self.connection_initiate_url.is_none()
         {
             return Err(ConfigError::MissingInitiateUrl);
         }
-        Ok(EndpointConfig {
+        Ok(NodeConfig {
             node_description: self.node_description,
             endpoint_description: self.endpoint_description,
             supported_message_versions: self.supported_message_versions,
@@ -312,11 +312,11 @@ pub enum PairingRole {
 
 /// The result of a pairing operation
 ///
-/// Describes the remote endpoint, and how communication between the nodes will happen.
+/// Describes the remote node, and how communication between the nodes will happen.
 pub struct Pairing {
     /// Description of the remote S2 Node.
     pub remote_node_description: S2NodeDescription,
-    /// Description of the remote S2 Endpoint.
+    /// Description of the remote S2 Endpoint hosting the node.
     pub remote_endpoint_description: S2EndpointDescription,
     /// Token used during communication setup.
     pub token: AccessToken,

--- a/s2energy-connection/src/pairing/server.rs
+++ b/s2energy-connection/src/pairing/server.rs
@@ -25,7 +25,7 @@ use crate::{
     pairing::PairingRole,
 };
 
-use super::{EndpointConfig, ErrorKind, Network, Pairing, PairingResult, wire::*};
+use super::{ErrorKind, Network, NodeConfig, Pairing, PairingResult, wire::*};
 
 const PERMANENT_PAIRING_BUFFER_SIZE: usize = 1;
 
@@ -104,8 +104,8 @@ impl Server {
             .with_state(self.state.clone())
     }
 
-    /// Start a one-time pairing session for the given endpoint using the given token.
-    pub fn pair_once(&self, config: Arc<EndpointConfig>, pairing_token: PairingToken) -> Result<PendingPairing, ErrorKind> {
+    /// Start a one-time pairing session for the given node using the given token.
+    pub fn pair_once(&self, config: Arc<NodeConfig>, pairing_token: PairingToken) -> Result<PendingPairing, ErrorKind> {
         if config.connection_initiate_url.is_none() {
             return Err(ErrorKind::InvalidConfig(super::ConfigError::MissingInitiateUrl));
         }
@@ -129,7 +129,7 @@ impl Server {
     }
 
     /// Allow repeated pairing sessions for the given endpoing using the given token.
-    pub fn pair_repeated(&self, config: Arc<EndpointConfig>, pairing_token: PairingToken) -> Result<RepeatedPairing, ErrorKind> {
+    pub fn pair_repeated(&self, config: Arc<NodeConfig>, pairing_token: PairingToken) -> Result<RepeatedPairing, ErrorKind> {
         if config.connection_initiate_url.is_none() {
             return Err(ErrorKind::InvalidConfig(super::ConfigError::MissingInitiateUrl));
         }
@@ -172,20 +172,20 @@ impl ResultSender {
 }
 
 struct PermanentPairingRequest {
-    config: Arc<EndpointConfig>,
+    config: Arc<NodeConfig>,
     sender: tokio::sync::mpsc::Sender<PairingResult<Pairing>>,
     token: PairingToken,
 }
 
 struct PairingRequest {
-    config: Arc<EndpointConfig>,
+    config: Arc<NodeConfig>,
     sender: ResultSender,
     token: PairingToken,
 }
 
 struct InitialPairingState {
     session_span: tracing::Span,
-    config: Arc<EndpointConfig>,
+    config: Arc<NodeConfig>,
     sender: ResultSender,
     challenge: HmacChallenge,
     token: PairingToken,


### PR DESCRIPTION
This better conveys the most specific item in the configuration. Closes #23 