### PR TITLE
Added some debug info for hmac su you can see domain/fingerprint used

### DIFF
--- a/s2energy-connection/src/pairing/mod.rs
+++ b/s2energy-connection/src/pairing/mod.rs
@@ -209,6 +209,7 @@ mod transport;
 pub(crate) mod wire;
 
 use rand::CryptoRng;
+use tracing::debug;
 
 use rustls::pki_types::CertificateDer;
 use wire::{HmacChallenge, HmacChallengeResponse};
@@ -399,14 +400,17 @@ impl HmacChallenge {
         use sha2::Sha256;
 
         let mut mac = Hmac::<Sha256>::new_from_slice(&self.0).expect("HMAC can take a key of any size");
+        debug!(?pairing_token, "Pairing token used for HMAC challenge response");
 
         match network {
             Network::Wan { domain } => {
+                debug!(domain = %domain, "WAN domain used for HMAC challenge response");
                 // R = HMAC(C, T)
                 mac.update(pairing_token);
                 mac.update(domain.as_bytes());
             }
             Network::Lan { fingerprint } => {
+                debug!(?fingerprint, "LAN fingerprint used for HMAC challenge response");
                 // R = HMAC(C, T || F)
                 mac.update(pairing_token);
                 mac.update(fingerprint);


### PR DESCRIPTION
To see it run like this:
` RUST_LOG=debug cargo run --example pairing-server`
It will show for example
`2026-07-28T15:37:53.181081Z DEBUG Pairing session{local=67e55044-10b1-426f-9247-bb680e5fe0c8 remote=0fb1278f-db28-4bf0-9f81-2277cf43d982}: s2energy_connection::pairing: WAN domain used for HMAC challenge response domain=s2connect.example.com`

or show the fingerprint if it's there.

I asked github copilot to add this so that I can check I'm using the correct domain name & calculating the correct fingerprint on the python side.