### PR TITLE
Use hexadecimal encoding and decoding for certificate fingerprints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2025,7 @@ dependencies = [
  "clap",
  "futures-util",
  "generic-array",
+ "hex",
  "hmac",
  "http",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ bon = "3.8.0"
 chrono = { version = "0.4.42", features = ["serde"] }
 futures-util = "0.3.31"
 generic-array = { version = "=0.14.7", features = ["serde"] }
+hex = "0.4.3"
 hmac = "0.12.1"
 http = "1.4.0"
 hyper = "1.8.1"

--- a/s2energy-connection/Cargo.toml
+++ b/s2energy-connection/Cargo.toml
@@ -9,6 +9,7 @@ axum-extra.workspace = true
 base64.workspace = true
 futures-util.workspace = true
 generic-array.workspace = true
+hex.workspace = true
 hmac.workspace = true
 http.workspace = true
 hyper.workspace = true

--- a/s2energy-connection/src/pairing/wire.rs
+++ b/s2energy-connection/src/pairing/wire.rs
@@ -247,20 +247,18 @@ pub(crate) struct ConnectionDetails {
 }
 
 pub(crate) fn serialize_fingerprint<S: Serializer>(value: &Option<CertificateHash>, serializer: S) -> Result<S::Ok, S::Error> {
-    use base64::{Engine, engine::general_purpose::STANDARD};
     // Unwrap is ok here as we serialize only when not none.
-    let encoded = STANDARD.encode(value.as_deref().unwrap() as &[u8]);
+    let encoded = hex::encode(value.as_deref().unwrap() as &[u8]);
     let mut map = serializer.serialize_map(Some(1))?;
     map.serialize_entry("SHA256", &encoded)?;
     map.end()
 }
 
 pub(crate) fn deserialize_fingerprint<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<CertificateHash>, D::Error> {
-    use base64::{Engine, engine::general_purpose::STANDARD};
     use std::{borrow::Cow, collections::HashMap};
     let data = HashMap::<Cow<'de, str>, Cow<'de, str>>::deserialize(deserializer)?;
     if let Some(hash) = data.get("SHA256") {
-        let decoded = STANDARD.decode(hash.as_ref()).map_err(de::Error::custom)?;
+        let decoded = hex::decode(hash.as_ref()).map_err(de::Error::custom)?;
         Ok(Some(CertificateHash(CertificateHashInner::Sha256(
             <[u8; 32]>::try_from(decoded)
                 .map_err(|_| de::Error::custom("Hash is wrong length"))?


### PR DESCRIPTION
The spec says: "SHA256 certificate fingerprints are encoded into a hexadecimal string, and must be decoded as hexadecimal string before it can be used as input".

Base64 was used before, resulting in hash length errors.