### PR TITLE
Use a readable example pairing token in `pairing-(client|server)` example

### DIFF
--- a/s2energy-connection/examples/pairing-client.rs
+++ b/s2energy-connection/examples/pairing-client.rs
@@ -8,7 +8,7 @@ use s2energy_connection::{
 };
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
-const PAIRING_TOKEN: &[u8] = &[1, 2, 3];
+const PAIRING_TOKEN: &[u8] = "anExamplePairingToken".as_bytes();
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {

--- a/s2energy-connection/examples/pairing-server.rs
+++ b/s2energy-connection/examples/pairing-server.rs
@@ -8,8 +8,7 @@ use s2energy_connection::{
 };
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
-#[allow(unused)]
-const PAIRING_TOKEN: &[u8] = &[1, 2, 3];
+const PAIRING_TOKEN: &[u8] = "anExamplePairingToken".as_bytes();
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {


### PR DESCRIPTION
Subjective, but makes it simpler to use the `paring-client` example with a different server.