### PR TITLE
Fix `WebSocketCommunicationDetails` property casing

### DIFF
--- a/s2energy-connection/src/communication/wire.rs
+++ b/s2energy-connection/src/communication/wire.rs
@@ -16,7 +16,9 @@ pub(crate) enum CommunicationDetails {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct WebSocketCommunicationDetails {
+    #[serde(rename = "websocketToken")]
     pub(crate) websocket_token: CommunicationToken,
+    #[serde(rename = "websocketUrl")]
     pub(crate) websocket_url: String,
 }
 


### PR DESCRIPTION
See https://github.com/flexiblepower/s2-connect/blob/main/openapi/s2-connect-session-init.yml#L158-L171